### PR TITLE
Release v1.0.0: 사다리타기 결과 위치 랜덤 배치 수정

### DIFF
--- a/src/components/games/LadderGame.tsx
+++ b/src/components/games/LadderGame.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
 import { LadderParticipant, LadderResult } from '@/types';
+import { shuffleArray } from '@/lib/random';
 
 interface HorizontalLine {
   fromIndex: number;
@@ -43,10 +44,12 @@ export default function LadderGame({ className = '' }: LadderGameProps) {
       id: `participant-${i}`,
       name: `참가자 ${i + 1}`,
     }));
-    const newResults: LadderResult[] = Array.from({ length: participantCount }, (_, i) => ({
-      id: `result-${i}`,
-      name: i === 0 ? '당첨' : '꽝',
-    }));
+    const newResults: LadderResult[] = shuffleArray(
+      Array.from({ length: participantCount }, (_, i) => ({
+        id: `result-${i}`,
+        name: i === 0 ? '당첨' : '꽝',
+      }))
+    );
     setParticipants(newParticipants);
     setResults(newResults);
     setRevealedResults(new Set());
@@ -284,6 +287,7 @@ export default function LadderGame({ className = '' }: LadderGameProps) {
   const handleRegenerate = () => {
     setRevealedResults(new Set());
     setSelectedIndex(null);
+    setResults(prevResults => shuffleArray(prevResults));
     generateLadder(participantCount);
   };
 


### PR DESCRIPTION
## Summary
- 사다리타기 게임에서 결과(당첨/꽝) 위치가 항상 입력 순서대로 배치되던 문제 수정
- `shuffleArray` 함수를 적용하여 게임 시작 및 재생성 시 결과 위치를 무작위로 섞도록 개선
- 게임성 향상을 위한 예측 불가능한 결과 배치 구현

## Test plan
- [ ] `/ladder` 페이지 접속 후 결과 위치가 랜덤하게 배치되는지 확인
- [ ] 참가자 수 변경 시 결과 위치가 랜덤인지 확인
- [ ] "사다리 새로 만들기" 클릭 시 결과 위치가 재셔플되는지 확인
- [ ] `npm run build` 정상 빌드 확인