### PR TITLE
feat: 게임 설정 프리셋 저장/불러오기 기능

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest",
-    "test:run": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "next": "^16.1.6",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,3 +33,9 @@ input, textarea, select, label, button, a,
 [class*="border-"] {
   transition: background-color 0.3s ease, border-color 0.3s ease, color 0.15s ease;
 }
+
+/* ConfirmDialog backdrop – scoped to data-confirm dialogs only */
+dialog[data-confirm]::backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}

--- a/src/components/games/LadderGame.tsx
+++ b/src/components/games/LadderGame.tsx
@@ -3,9 +3,11 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
+import PresetPanel from '@/components/ui/PresetPanel';
 import { LadderParticipant, LadderResult } from '@/types';
 import { shuffleArray, generateRandomNumber } from '@/lib/random';
 import { useTheme } from '@/hooks/useTheme';
+import type { LadderPresetData } from '@/types/preset';
 
 interface HorizontalLine {
   fromIndex: number;
@@ -33,6 +35,7 @@ export default function LadderGame({ className = '' }: LadderGameProps) {
   const [isAnimating, setIsAnimating] = useState(false);
   const [revealedResults, setRevealedResults] = useState<Set<number>>(new Set());
   const animationFrameRef = useRef<number | undefined>(undefined);
+  const pendingPresetRef = useRef<LadderPresetData | null>(null);
 
   const CANVAS_WIDTH = 800;
   const CANVAS_HEIGHT = 600;
@@ -74,21 +77,35 @@ export default function LadderGame({ className = '' }: LadderGameProps) {
 
   // 참가자 수 변경 시 초기화
   useEffect(() => {
+    const pending = pendingPresetRef.current;
+
     const newParticipants: LadderParticipant[] = Array.from({ length: participantCount }, (_, i) => ({
       id: `participant-${i}`,
-      name: `참가자 ${i + 1}`,
+      name: pending?.participantNames[i] ?? `참가자 ${i + 1}`,
     }));
-    const newResults: LadderResult[] = shuffleArray(
-      Array.from({ length: participantCount }, (_, i) => ({
+
+    let newResults: LadderResult[];
+    if (pending) {
+      newResults = Array.from({ length: participantCount }, (_, i) => ({
         id: `result-${i}`,
-        name: i === 0 ? '당첨' : '꽝',
-      }))
-    );
+        name: pending.resultNames[i] ?? `결과 ${i + 1}`,
+      }));
+    } else {
+      newResults = shuffleArray(
+        Array.from({ length: participantCount }, (_, i) => ({
+          id: `result-${i}`,
+          name: i === 0 ? '당첨' : '꽝',
+        }))
+      );
+    }
+
     setParticipants(newParticipants);
     setResults(newResults);
     setRevealedResults(new Set());
     setSelectedIndex(null);
     generateLadder(participantCount);
+
+    pendingPresetRef.current = null;
   }, [participantCount, generateLadder]);
 
   // animationFrame cleanup (메모리 누수 방지)
@@ -308,6 +325,34 @@ export default function LadderGame({ className = '' }: LadderGameProps) {
     setSelectedIndex(null);
   };
 
+  // 프리셋 이름 즉시 적용 (count가 동일할 때)
+  const applyPresetNames = (data: LadderPresetData) => {
+    setParticipants(prev =>
+      prev.map((p, i) => ({
+        ...p,
+        name: data.participantNames[i] ?? p.name,
+      }))
+    );
+    setResults(prev =>
+      prev.map((r, i) => ({
+        ...r,
+        name: data.resultNames[i] ?? r.name,
+      }))
+    );
+    setRevealedResults(new Set());
+    setSelectedIndex(null);
+  };
+
+  // 프리셋 불러오기 핸들러
+  const handlePresetLoad = (data: LadderPresetData) => {
+    if (data.participantCount !== participantCount) {
+      pendingPresetRef.current = data;
+      setParticipantCount(data.participantCount);
+    } else {
+      applyPresetNames(data);
+    }
+  };
+
   return (
     <div className={`flex flex-col lg:flex-row gap-6 ${className}`}>
       {/* 설정 패널 */}
@@ -366,8 +411,19 @@ export default function LadderGame({ className = '' }: LadderGameProps) {
           </div>
         </div>
 
+        <PresetPanel<LadderPresetData>
+          gameType="ladder"
+          getCurrentData={() => ({
+            participantCount,
+            participantNames: participants.map((p) => p.name),
+            resultNames: results.map((r) => r.name),
+          })}
+          onLoad={handlePresetLoad}
+          disabled={isAnimating}
+        />
+
         {/* 버튼들 */}
-        <div className="space-y-2">
+        <div className="space-y-2 mt-4">
           <Button
             onClick={handleRegenerate}
             disabled={isAnimating}

--- a/src/components/games/NamePicker.tsx
+++ b/src/components/games/NamePicker.tsx
@@ -3,7 +3,9 @@
 import { useState, useEffect, useRef } from 'react';
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
+import PresetPanel from '@/components/ui/PresetPanel';
 import { pickRandomMultiple, pickRandom } from '@/lib/random';
+import type { NamePresetData } from '@/types/preset';
 
 interface Winner {
   name: string;
@@ -258,6 +260,18 @@ export default function NamePicker() {
                 </p>
               )}
             </div>
+
+            <PresetPanel<NamePresetData>
+              gameType="name"
+              getCurrentData={() => ({ names: inputText, pickCount, removeAfterPick })}
+              onLoad={(data) => {
+                setInputText(data.names);
+                setNames(data.names.split('\n').map((s) => s.trim()).filter(Boolean));
+                setPickCount(data.pickCount);
+                setRemoveAfterPick(data.removeAfterPick);
+              }}
+              disabled={isSpinning}
+            />
           </Card>
         </div>
 

--- a/src/components/games/NumberPicker.tsx
+++ b/src/components/games/NumberPicker.tsx
@@ -3,7 +3,9 @@
 import { useState, useEffect, useRef } from 'react';
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
+import PresetPanel from '@/components/ui/PresetPanel';
 import { generateRandomNumber, pickRandom } from '@/lib/random';
+import type { NumberPresetData } from '@/types/preset';
 
 interface PickedNumber {
   value: number;
@@ -307,6 +309,19 @@ export default function NumberPicker() {
                 <p>• 정렬: {sortResults ? '오름차순' : '추첨 순서'}</p>
               </div>
             </div>
+
+            <PresetPanel<NumberPresetData>
+              gameType="number"
+              getCurrentData={() => ({ minValue, maxValue, pickCount, allowDuplicates, sortResults })}
+              onLoad={(data) => {
+                setMinValue(data.minValue);
+                setMaxValue(data.maxValue);
+                setPickCount(data.pickCount);
+                setAllowDuplicates(data.allowDuplicates);
+                setSortResults(data.sortResults);
+              }}
+              disabled={isSpinning}
+            />
           </Card>
         </div>
 

--- a/src/components/games/PrizePicker.tsx
+++ b/src/components/games/PrizePicker.tsx
@@ -3,7 +3,9 @@
 import { useState, useEffect, useRef } from 'react';
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
+import PresetPanel from '@/components/ui/PresetPanel';
 import { pickRandom } from '@/lib/random';
+import type { PrizePresetData } from '@/types/preset';
 
 export default function PrizePicker() {
   const [inputText, setInputText] = useState('');
@@ -158,6 +160,16 @@ export default function PrizePicker() {
                 </p>
               )}
             </div>
+
+            <PresetPanel<PrizePresetData>
+              gameType="prize"
+              getCurrentData={() => ({ items: inputText })}
+              onLoad={(data) => {
+                setInputText(data.items);
+                setItems(data.items.split('\n').map((s) => s.trim()).filter(Boolean));
+              }}
+              disabled={isSpinning}
+            />
           </Card>
         </div>
 

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useRef, useEffect, useId, useCallback } from 'react';
+import { MESSAGES } from '@/lib/messages';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'default' | 'danger';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = MESSAGES.common.confirm,
+  cancelLabel = MESSAGES.common.cancel,
+  variant = 'default',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const id = useId();
+  const titleId = `${id}-title`;
+  const descId = `${id}-desc`;
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (open) {
+      if (!dialog.open) {
+        dialog.showModal();
+      }
+      // Focus the cancel button for safe default on dangerous actions
+      cancelRef.current?.focus();
+    } else {
+      if (dialog.open) {
+        dialog.close();
+      }
+    }
+  }, [open]);
+
+  const handleCancel = useCallback(
+    (e: React.SyntheticEvent) => {
+      e.preventDefault();
+      onCancel();
+    },
+    [onCancel],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDialogElement>) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    },
+    [onCancel],
+  );
+
+  if (!open) return null;
+
+  const confirmButtonClass =
+    variant === 'danger'
+      ? 'bg-red-600 hover:bg-red-700 focus:ring-red-500 dark:bg-red-500 dark:hover:bg-red-600'
+      : 'bg-blue-600 hover:bg-blue-700 focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600';
+
+  return (
+    <dialog
+      ref={dialogRef}
+      role="dialog"
+      data-confirm
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+      onCancel={handleCancel}
+      onKeyDown={handleKeyDown}
+      className="fixed inset-0 z-50 m-auto rounded-xl bg-white p-0 shadow-2xl dark:bg-slate-800"
+    >
+      <div className="w-80 p-6">
+        <h2
+          id={titleId}
+          className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+        >
+          {title}
+        </h2>
+        <p
+          id={descId}
+          className="mt-2 text-sm text-gray-600 dark:text-gray-300"
+        >
+          {message}
+        </p>
+        <div className="mt-6 flex gap-3">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:border-slate-600 dark:text-gray-300 dark:hover:bg-slate-700"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`flex-1 rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${confirmButtonClass}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/src/components/ui/PresetPanel.tsx
+++ b/src/components/ui/PresetPanel.tsx
@@ -1,16 +1,23 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import type { GameType } from '@/types/index';
 import type { PresetData } from '@/types/preset';
 import { usePreset } from '@/hooks/usePreset';
 import { MAX_PRESET_NAME_LENGTH } from '@/lib/presetStorage';
+import { MESSAGES } from '@/lib/messages';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
 
 interface PresetPanelProps<T extends PresetData> {
   gameType: GameType;
   getCurrentData: () => T;
   onLoad: (data: T) => void;
   disabled?: boolean;
+}
+
+interface DeleteTarget {
+  id: string;
+  name: string;
 }
 
 function formatDate(timestamp: number): string {
@@ -30,6 +37,7 @@ export default function PresetPanel<T extends PresetData>({
   const [isSaving, setIsSaving] = useState(false);
   const [nameInput, setNameInput] = useState('');
   const [nameError, setNameError] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
 
   const handleSaveClick = () => {
     setIsSaving(true);
@@ -46,7 +54,7 @@ export default function PresetPanel<T extends PresetData>({
   const handleConfirmSave = () => {
     const trimmed = nameInput.trim();
     if (!trimmed) {
-      setNameError('설정 이름을 입력해주세요.');
+      setNameError(MESSAGES.preset.errors.nameRequired);
       return;
     }
     const data = getCurrentData();
@@ -63,10 +71,20 @@ export default function PresetPanel<T extends PresetData>({
     }
   };
 
-  const handleDelete = (id: string, name: string) => {
-    if (!window.confirm(`"${name}" 설정을 삭제하시겠습니까?`)) return;
-    deletePreset(id);
+  const handleDeleteClick = (id: string, name: string) => {
+    setDeleteTarget({ id, name });
   };
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (deleteTarget) {
+      deletePreset(deleteTarget.id);
+      setDeleteTarget(null);
+    }
+  }, [deleteTarget, deletePreset]);
+
+  const handleDeleteCancel = useCallback(() => {
+    setDeleteTarget(null);
+  }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -79,14 +97,14 @@ export default function PresetPanel<T extends PresetData>({
   return (
     <div className="mt-4 pt-4 border-t border-gray-200">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-medium text-gray-700">저장된 설정</h3>
+        <h3 className="text-sm font-medium text-gray-700">{MESSAGES.preset.title}</h3>
         {!isSaving && (
           <button
             onClick={handleSaveClick}
             disabled={disabled}
             className="text-xs text-blue-600 hover:text-blue-800 font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
-            + 현재 설정 저장
+            {MESSAGES.preset.saveButton}
           </button>
         )}
       </div>
@@ -94,7 +112,7 @@ export default function PresetPanel<T extends PresetData>({
       {/* 이름 입력 폼 */}
       {isSaving && (
         <div className="mb-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-          <p className="text-xs font-medium text-blue-700 mb-2">설정 이름 입력</p>
+          <p className="text-xs font-medium text-blue-700 mb-2">{MESSAGES.preset.nameInputLabel}</p>
           <input
             type="text"
             value={nameInput}
@@ -104,7 +122,7 @@ export default function PresetPanel<T extends PresetData>({
               if (nameError) setNameError('');
             }}
             onKeyDown={handleKeyDown}
-            placeholder="예: 로또 기본 설정"
+            placeholder={MESSAGES.preset.nameInputPlaceholder}
             autoFocus
             className="w-full px-2 py-1.5 text-sm border border-blue-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-transparent"
           />
@@ -116,13 +134,13 @@ export default function PresetPanel<T extends PresetData>({
               onClick={handleConfirmSave}
               className="flex-1 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 rounded transition-colors"
             >
-              저장
+              {MESSAGES.common.save}
             </button>
             <button
               onClick={handleCancelSave}
               className="flex-1 py-1.5 text-xs font-medium text-gray-600 bg-white border border-gray-300 hover:bg-gray-50 rounded transition-colors"
             >
-              취소
+              {MESSAGES.common.cancel}
             </button>
           </div>
         </div>
@@ -145,20 +163,34 @@ export default function PresetPanel<T extends PresetData>({
                 disabled={disabled}
                 className="flex-shrink-0 px-2 py-1 text-xs font-medium text-blue-600 hover:text-blue-800 hover:bg-blue-50 rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
-                불러오기
+                {MESSAGES.common.load}
               </button>
               <button
-                onClick={() => handleDelete(preset.id, preset.name)}
+                onClick={() => handleDeleteClick(preset.id, preset.name)}
                 disabled={disabled}
                 className="flex-shrink-0 px-2 py-1 text-xs font-medium text-red-500 hover:text-red-700 hover:bg-red-50 rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
-                삭제
+                {MESSAGES.common.delete}
               </button>
             </div>
           ))}
         </div>
       ) : (
-        <p className="text-xs text-gray-400 text-center py-3">저장된 설정이 없습니다</p>
+        <p className="text-xs text-gray-400 text-center py-3">{MESSAGES.preset.emptyState}</p>
+      )}
+
+      {/* 삭제 확인 다이얼로그 */}
+      {deleteTarget && (
+        <ConfirmDialog
+          open
+          title={MESSAGES.confirmDialog.deleteTitle}
+          message={MESSAGES.confirmDialog.deleteMessage(deleteTarget.name)}
+          confirmLabel={MESSAGES.common.delete}
+          cancelLabel={MESSAGES.common.cancel}
+          variant="danger"
+          onConfirm={handleDeleteConfirm}
+          onCancel={handleDeleteCancel}
+        />
       )}
     </div>
   );

--- a/src/components/ui/PresetPanel.tsx
+++ b/src/components/ui/PresetPanel.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useState } from 'react';
+import type { GameType } from '@/types/index';
+import type { PresetData } from '@/types/preset';
+import { usePreset } from '@/hooks/usePreset';
+import { MAX_PRESET_NAME_LENGTH } from '@/lib/presetStorage';
+
+interface PresetPanelProps<T extends PresetData> {
+  gameType: GameType;
+  getCurrentData: () => T;
+  onLoad: (data: T) => void;
+  disabled?: boolean;
+}
+
+function formatDate(timestamp: number): string {
+  const d = new Date(timestamp);
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${mm}/${dd}`;
+}
+
+export default function PresetPanel<T extends PresetData>({
+  gameType,
+  getCurrentData,
+  onLoad,
+  disabled = false,
+}: PresetPanelProps<T>) {
+  const { presets, savePreset, loadPreset, deletePreset } = usePreset<T>(gameType);
+  const [isSaving, setIsSaving] = useState(false);
+  const [nameInput, setNameInput] = useState('');
+  const [nameError, setNameError] = useState('');
+
+  const handleSaveClick = () => {
+    setIsSaving(true);
+    setNameInput('');
+    setNameError('');
+  };
+
+  const handleCancelSave = () => {
+    setIsSaving(false);
+    setNameInput('');
+    setNameError('');
+  };
+
+  const handleConfirmSave = () => {
+    const trimmed = nameInput.trim();
+    if (!trimmed) {
+      setNameError('설정 이름을 입력해주세요.');
+      return;
+    }
+    const data = getCurrentData();
+    savePreset(trimmed, data);
+    setIsSaving(false);
+    setNameInput('');
+    setNameError('');
+  };
+
+  const handleLoad = (id: string) => {
+    const data = loadPreset(id);
+    if (data) {
+      onLoad(data);
+    }
+  };
+
+  const handleDelete = (id: string, name: string) => {
+    if (!window.confirm(`"${name}" 설정을 삭제하시겠습니까?`)) return;
+    deletePreset(id);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleConfirmSave();
+    } else if (e.key === 'Escape') {
+      handleCancelSave();
+    }
+  };
+
+  return (
+    <div className="mt-4 pt-4 border-t border-gray-200">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium text-gray-700">저장된 설정</h3>
+        {!isSaving && (
+          <button
+            onClick={handleSaveClick}
+            disabled={disabled}
+            className="text-xs text-blue-600 hover:text-blue-800 font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            + 현재 설정 저장
+          </button>
+        )}
+      </div>
+
+      {/* 이름 입력 폼 */}
+      {isSaving && (
+        <div className="mb-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+          <p className="text-xs font-medium text-blue-700 mb-2">설정 이름 입력</p>
+          <input
+            type="text"
+            value={nameInput}
+            maxLength={MAX_PRESET_NAME_LENGTH}
+            onChange={(e) => {
+              setNameInput(e.target.value);
+              if (nameError) setNameError('');
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="예: 로또 기본 설정"
+            autoFocus
+            className="w-full px-2 py-1.5 text-sm border border-blue-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-transparent"
+          />
+          {nameError && (
+            <p className="mt-1 text-xs text-red-500">{nameError}</p>
+          )}
+          <div className="mt-2 flex gap-2">
+            <button
+              onClick={handleConfirmSave}
+              className="flex-1 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 rounded transition-colors"
+            >
+              저장
+            </button>
+            <button
+              onClick={handleCancelSave}
+              className="flex-1 py-1.5 text-xs font-medium text-gray-600 bg-white border border-gray-300 hover:bg-gray-50 rounded transition-colors"
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* 프리셋 목록 */}
+      {presets.length > 0 ? (
+        <div className="space-y-1.5">
+          {presets.map((preset) => (
+            <div
+              key={preset.id}
+              className="flex items-center gap-2 px-3 py-2 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-800 truncate">{preset.name}</p>
+                <p className="text-xs text-gray-400">{formatDate(preset.createdAt)}</p>
+              </div>
+              <button
+                onClick={() => handleLoad(preset.id)}
+                disabled={disabled}
+                className="flex-shrink-0 px-2 py-1 text-xs font-medium text-blue-600 hover:text-blue-800 hover:bg-blue-50 rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                불러오기
+              </button>
+              <button
+                onClick={() => handleDelete(preset.id, preset.name)}
+                disabled={disabled}
+                className="flex-shrink-0 px-2 py-1 text-xs font-medium text-red-500 hover:text-red-700 hover:bg-red-50 rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                삭제
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-gray-400 text-center py-3">저장된 설정이 없습니다</p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/usePreset.ts
+++ b/src/hooks/usePreset.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { GameType } from '@/types/index';
+import type { Preset, PresetData } from '@/types/preset';
+import {
+  getPresets,
+  savePreset as storageSavePreset,
+  deletePreset as storageDeletePreset,
+} from '@/lib/presetStorage';
+
+interface UsePresetReturn<T extends PresetData> {
+  presets: Preset<T>[];
+  savePreset: (name: string, data: T) => void;
+  loadPreset: (id: string) => T | null;
+  deletePreset: (id: string) => void;
+}
+
+export function usePreset<T extends PresetData>(
+  gameType: GameType
+): UsePresetReturn<T> {
+  const [presets, setPresets] = useState<Preset<T>[]>(() =>
+    getPresets<T>(gameType)
+  );
+
+  useEffect(() => {
+    setPresets(getPresets<T>(gameType));
+  }, [gameType]);
+
+  const savePreset = useCallback(
+    (name: string, data: T) => {
+      storageSavePreset<T>(gameType, name, data);
+      setPresets(getPresets<T>(gameType));
+    },
+    [gameType]
+  );
+
+  const loadPreset = useCallback(
+    (id: string): T | null => {
+      const found = presets.find((p) => p.id === id);
+      return found ? found.data : null;
+    },
+    [presets]
+  );
+
+  const deletePreset = useCallback(
+    (id: string) => {
+      storageDeletePreset(gameType, id);
+      setPresets(getPresets<T>(gameType));
+    },
+    [gameType]
+  );
+
+  return { presets, savePreset, loadPreset, deletePreset };
+}

--- a/src/hooks/usePreset.ts
+++ b/src/hooks/usePreset.ts
@@ -11,7 +11,7 @@ interface UsePresetReturn<T extends PresetData> {
   presets: Preset<T>[];
   savePreset: (name: string, data: T) => void;
   loadPreset: (id: string) => T | null;
-  deletePreset: (id: string) => void;
+  deletePreset: (id: string) => boolean;
 }
 
 export function usePreset<T extends PresetData>(
@@ -42,9 +42,10 @@ export function usePreset<T extends PresetData>(
   );
 
   const deletePreset = useCallback(
-    (id: string) => {
-      storageDeletePreset(gameType, id);
+    (id: string): boolean => {
+      const result = storageDeletePreset(gameType, id);
       setPresets(getPresets<T>(gameType));
+      return result;
     },
     [gameType]
   );

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,0 +1,35 @@
+/**
+ * UI text constants.
+ *
+ * All user-facing strings are centralised here so they can be
+ * swapped for a full i18n solution later without a scattered diff.
+ */
+
+export const MESSAGES = {
+  // ── Common ────────────────────────────────────────────────
+  common: {
+    confirm: '확인',
+    cancel: '취소',
+    save: '저장',
+    delete: '삭제',
+    load: '불러오기',
+  },
+
+  // ── PresetPanel ───────────────────────────────────────────
+  preset: {
+    title: '저장된 설정',
+    saveButton: '+ 현재 설정 저장',
+    nameInputLabel: '설정 이름 입력',
+    nameInputPlaceholder: '예: 로또 기본 설정',
+    emptyState: '저장된 설정이 없습니다',
+    errors: {
+      nameRequired: '설정 이름을 입력해주세요.',
+    },
+  },
+
+  // ── ConfirmDialog ─────────────────────────────────────────
+  confirmDialog: {
+    deleteTitle: '설정 삭제',
+    deleteMessage: (name: string) => `"${name}" 설정을 삭제하시겠습니까?`,
+  },
+} as const;

--- a/src/lib/presetStorage.ts
+++ b/src/lib/presetStorage.ts
@@ -1,11 +1,29 @@
 import type { GameType } from '@/types/index';
-import type { Preset, PresetData } from '@/types/preset';
+import type {
+  Preset,
+  PresetData,
+  PrizePresetData,
+  NamePresetData,
+  NumberPresetData,
+  LadderPresetData,
+} from '@/types/preset';
 
 export const STORAGE_KEY_PREFIX = 'lucky-pick-presets-';
 export const MAX_PRESETS_PER_GAME = 5;
 export const MAX_PRESET_NAME_LENGTH = 30;
+export const MAX_PRESET_DATA_SIZE = 50_000;
 
+/**
+ * Generate a unique ID using crypto.randomUUID with fallback.
+ */
 function generateId(): string {
+  try {
+    if (typeof globalThis.crypto?.randomUUID === 'function') {
+      return globalThis.crypto.randomUUID();
+    }
+  } catch {
+    // fallback below
+  }
   return Date.now().toString(36) + Math.random().toString(36).slice(2);
 }
 
@@ -14,18 +32,77 @@ function getStorageKey(gameType: GameType): string {
 }
 
 /**
- * Validates that an unknown value has the shape of a Preset object.
+ * Remove dangerous characters (<>"'&) from a name string.
+ */
+function sanitizeName(name: string): string {
+  return name.replace(/[<>"'&]/g, '');
+}
+
+/**
+ * Validates game-specific data structure.
+ */
+function isValidPresetData(gameType: string, data: unknown): boolean {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  switch (gameType) {
+    case 'prize': {
+      const d = data as PrizePresetData;
+      return typeof d.items === 'string';
+    }
+    case 'name': {
+      const d = data as NamePresetData;
+      return (
+        typeof d.names === 'string' &&
+        typeof d.pickCount === 'number' &&
+        typeof d.removeAfterPick === 'boolean'
+      );
+    }
+    case 'number': {
+      const d = data as NumberPresetData;
+      return (
+        typeof d.minValue === 'number' &&
+        typeof d.maxValue === 'number' &&
+        typeof d.pickCount === 'number' &&
+        typeof d.allowDuplicates === 'boolean' &&
+        typeof d.sortResults === 'boolean'
+      );
+    }
+    case 'ladder': {
+      const d = data as LadderPresetData;
+      return (
+        typeof d.participantCount === 'number' &&
+        Array.isArray(d.participantNames) &&
+        Array.isArray(d.resultNames)
+      );
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * Validates that an unknown value has the shape of a Preset object,
+ * including game-specific data validation.
  */
 function isValidPreset(item: unknown): item is Preset {
-  return (
-    typeof item === 'object' &&
-    item !== null &&
-    typeof (item as Preset).id === 'string' &&
-    typeof (item as Preset).name === 'string' &&
-    typeof (item as Preset).gameType === 'string' &&
-    typeof (item as Preset).createdAt === 'number' &&
-    typeof (item as Preset).data === 'object' &&
-    (item as Preset).data !== null
+  if (
+    typeof item !== 'object' ||
+    item === null ||
+    typeof (item as Preset).id !== 'string' ||
+    typeof (item as Preset).name !== 'string' ||
+    typeof (item as Preset).gameType !== 'string' ||
+    typeof (item as Preset).createdAt !== 'number' ||
+    typeof (item as Preset).data !== 'object' ||
+    (item as Preset).data === null
+  ) {
+    return false;
+  }
+
+  return isValidPresetData(
+    (item as Preset).gameType,
+    (item as Preset).data
   );
 }
 
@@ -58,16 +135,29 @@ export function getPresets<T extends PresetData>(gameType: GameType): Preset<T>[
 
 /**
  * Save a new preset for the given game type.
- * If the number of presets exceeds MAX_PRESETS_PER_GAME, the oldest is removed.
- * Name is truncated to MAX_PRESET_NAME_LENGTH characters.
- * Returns the newly created preset, or null if localStorage write fails.
+ * - Name is sanitized (dangerous chars removed), trimmed, and truncated.
+ * - Returns null if name is empty after processing, data exceeds size limit,
+ *   or localStorage write fails.
+ * - If the number of presets exceeds MAX_PRESETS_PER_GAME, the oldest is removed.
  */
 export function savePreset<T extends PresetData>(
   gameType: GameType,
   name: string,
   data: T
 ): Preset<T> | null {
-  const safeName = name.slice(0, MAX_PRESET_NAME_LENGTH);
+  // L-1: Check data size
+  const dataJson = JSON.stringify(data);
+  if (dataJson.length > MAX_PRESET_DATA_SIZE) {
+    return null;
+  }
+
+  // H-1: Sanitize dangerous characters, L-2: trim whitespace
+  const safeName = sanitizeName(name).trim().slice(0, MAX_PRESET_NAME_LENGTH);
+
+  // L-2: Empty name after sanitization + trim
+  if (safeName.length === 0) {
+    return null;
+  }
 
   const preset: Preset<T> = {
     id: generateId(),
@@ -96,15 +186,22 @@ export function savePreset<T extends PresetData>(
 
 /**
  * Delete a preset by ID for the given game type.
- * Does nothing if the ID does not exist.
+ * Returns true if the preset was found and deleted, false otherwise.
  */
-export function deletePreset(gameType: GameType, presetId: string): void {
+export function deletePreset(gameType: GameType, presetId: string): boolean {
   const existing = getPresets(gameType);
   const filtered = existing.filter((p) => p.id !== presetId);
+
+  // If lengths are equal, nothing was deleted
+  if (filtered.length === existing.length) {
+    return false;
+  }
 
   try {
     localStorage.setItem(getStorageKey(gameType), JSON.stringify(filtered));
   } catch {
-    // localStorage unavailable - fail silently
+    return false;
   }
+
+  return true;
 }

--- a/src/lib/presetStorage.ts
+++ b/src/lib/presetStorage.ts
@@ -1,0 +1,110 @@
+import type { GameType } from '@/types/index';
+import type { Preset, PresetData } from '@/types/preset';
+
+export const STORAGE_KEY_PREFIX = 'lucky-pick-presets-';
+export const MAX_PRESETS_PER_GAME = 5;
+export const MAX_PRESET_NAME_LENGTH = 30;
+
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2);
+}
+
+function getStorageKey(gameType: GameType): string {
+  return `${STORAGE_KEY_PREFIX}${gameType}`;
+}
+
+/**
+ * Validates that an unknown value has the shape of a Preset object.
+ */
+function isValidPreset(item: unknown): item is Preset {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    typeof (item as Preset).id === 'string' &&
+    typeof (item as Preset).name === 'string' &&
+    typeof (item as Preset).gameType === 'string' &&
+    typeof (item as Preset).createdAt === 'number' &&
+    typeof (item as Preset).data === 'object' &&
+    (item as Preset).data !== null
+  );
+}
+
+/**
+ * Retrieve all presets for a given game type from localStorage.
+ * Returns an empty array if no presets exist, data is corrupted, or SSR.
+ * Invalid entries are filtered out to guard against manually tampered data.
+ */
+export function getPresets<T extends PresetData>(gameType: GameType): Preset<T>[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(getStorageKey(gameType));
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(isValidPreset) as Preset<T>[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Save a new preset for the given game type.
+ * If the number of presets exceeds MAX_PRESETS_PER_GAME, the oldest is removed.
+ * Name is truncated to MAX_PRESET_NAME_LENGTH characters.
+ * Returns the newly created preset, or null if localStorage write fails.
+ */
+export function savePreset<T extends PresetData>(
+  gameType: GameType,
+  name: string,
+  data: T
+): Preset<T> | null {
+  const safeName = name.slice(0, MAX_PRESET_NAME_LENGTH);
+
+  const preset: Preset<T> = {
+    id: generateId(),
+    name: safeName,
+    gameType,
+    data,
+    createdAt: Date.now(),
+  };
+
+  const existing = getPresets<T>(gameType);
+  existing.push(preset);
+
+  // Evict oldest presets if over the limit, keeping only the most recent
+  const trimmed = existing.length > MAX_PRESETS_PER_GAME
+    ? existing.slice(-MAX_PRESETS_PER_GAME)
+    : existing;
+
+  try {
+    localStorage.setItem(getStorageKey(gameType), JSON.stringify(trimmed));
+  } catch {
+    return null;
+  }
+
+  return preset;
+}
+
+/**
+ * Delete a preset by ID for the given game type.
+ * Does nothing if the ID does not exist.
+ */
+export function deletePreset(gameType: GameType, presetId: string): void {
+  const existing = getPresets(gameType);
+  const filtered = existing.filter((p) => p.id !== presetId);
+
+  try {
+    localStorage.setItem(getStorageKey(gameType), JSON.stringify(filtered));
+  } catch {
+    // localStorage unavailable - fail silently
+  }
+}

--- a/src/test/ConfirmDialog.test.tsx
+++ b/src/test/ConfirmDialog.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
+
+// Dialog polyfill is installed globally in src/test/setup.ts
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    open: true,
+    title: '삭제 확인',
+    message: '정말 삭제하시겠습니까?',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── Rendering ────────────────────────────────────────────
+
+  describe('렌더링', () => {
+    it('open=false일 때 다이얼로그 내용이 보이지 않는다', () => {
+      render(<ConfirmDialog {...defaultProps} open={false} />);
+
+      expect(screen.queryByText('삭제 확인')).not.toBeInTheDocument();
+    });
+
+    it('open=true일 때 다이얼로그가 표시된다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByText('삭제 확인')).toBeInTheDocument();
+      expect(screen.getByText('정말 삭제하시겠습니까?')).toBeInTheDocument();
+    });
+
+    it('title과 message를 렌더링한다', () => {
+      render(
+        <ConfirmDialog
+          {...defaultProps}
+          title="커스텀 제목"
+          message="커스텀 메시지"
+        />,
+      );
+
+      expect(screen.getByText('커스텀 제목')).toBeInTheDocument();
+      expect(screen.getByText('커스텀 메시지')).toBeInTheDocument();
+    });
+
+    it('기본 confirmLabel은 "확인"이다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: '확인' })).toBeInTheDocument();
+    });
+
+    it('기본 cancelLabel은 "취소"이다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: '취소' })).toBeInTheDocument();
+    });
+
+    it('커스텀 confirmLabel을 렌더링한다', () => {
+      render(<ConfirmDialog {...defaultProps} confirmLabel="삭제" />);
+
+      expect(screen.getByRole('button', { name: '삭제' })).toBeInTheDocument();
+    });
+
+    it('커스텀 cancelLabel을 렌더링한다', () => {
+      render(<ConfirmDialog {...defaultProps} cancelLabel="돌아가기" />);
+
+      expect(screen.getByRole('button', { name: '돌아가기' })).toBeInTheDocument();
+    });
+  });
+
+  // ─── Interactions ─────────────────────────────────────────
+
+  describe('상호작용', () => {
+    it('확인 버튼 클릭 시 onConfirm이 호출된다', async () => {
+      const user = userEvent.setup();
+      render(<ConfirmDialog {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: '확인' }));
+
+      expect(defaultProps.onConfirm).toHaveBeenCalledOnce();
+    });
+
+    it('취소 버튼 클릭 시 onCancel이 호출된다', async () => {
+      const user = userEvent.setup();
+      render(<ConfirmDialog {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: '취소' }));
+
+      expect(defaultProps.onCancel).toHaveBeenCalledOnce();
+    });
+
+    it('Escape 키 입력 시 onCancel이 호출된다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      fireEvent.keyDown(dialog, { key: 'Escape' });
+
+      expect(defaultProps.onCancel).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ─── Variants ─────────────────────────────────────────────
+
+  describe('variant', () => {
+    it('variant="danger"일 때 확인 버튼에 빨간색 스타일이 적용된다', () => {
+      render(<ConfirmDialog {...defaultProps} variant="danger" />);
+
+      const confirmButton = screen.getByRole('button', { name: '확인' });
+      expect(confirmButton.className).toMatch(/bg-red/);
+    });
+
+    it('variant 미지정 시 확인 버튼에 파란색 스타일이 적용된다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      const confirmButton = screen.getByRole('button', { name: '확인' });
+      expect(confirmButton.className).toMatch(/bg-blue/);
+    });
+  });
+
+  // ─── Accessibility ────────────────────────────────────────
+
+  describe('접근성', () => {
+    it('dialog role을 가진다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('aria-labelledby로 제목과 연결된다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      const titleId = dialog.getAttribute('aria-labelledby');
+      expect(titleId).toBeTruthy();
+
+      const titleElement = document.getElementById(titleId!);
+      expect(titleElement).toHaveTextContent('삭제 확인');
+    });
+
+    it('aria-describedby로 메시지와 연결된다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      const descId = dialog.getAttribute('aria-describedby');
+      expect(descId).toBeTruthy();
+
+      const descElement = document.getElementById(descId!);
+      expect(descElement).toHaveTextContent('정말 삭제하시겠습니까?');
+    });
+
+    // H-1: Cancel button receives focus when dialog opens (safe default)
+    it('다이얼로그가 열리면 취소 버튼에 포커스가 이동한다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      const cancelButton = screen.getByRole('button', { name: '취소' });
+      expect(document.activeElement).toBe(cancelButton);
+    });
+
+    // M-2: dialog has data-confirm attribute for CSS scoping
+    it('dialog 요소에 data-confirm 속성이 있다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('data-confirm');
+    });
+
+    // L-2: No inline backdrop Tailwind classes (use globals.css only)
+    it('dialog 요소에 인라인 backdrop Tailwind 클래스가 없다', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog.className).not.toMatch(/backdrop:/);
+    });
+  });
+});

--- a/src/test/LadderGame.test.tsx
+++ b/src/test/LadderGame.test.tsx
@@ -90,7 +90,7 @@ describe('Issue H-1: LadderGame에서 Math.random() 직접 사용 금지', () =>
   it('LadderGame 소스코드에 Math.random()이 직접 사용되지 않아야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/LadderGame.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/LadderGame.tsx',
       'utf-8',
     );
 
@@ -102,7 +102,7 @@ describe('Issue H-1: LadderGame에서 Math.random() 직접 사용 금지', () =>
   it('generateRandomNumber를 import하여 사용해야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/LadderGame.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/LadderGame.tsx',
       'utf-8',
     );
 
@@ -149,7 +149,7 @@ describe('Issue #3: useEffect dependency - generateLadder', () => {
   it('generateLadder가 useEffect 의존성 배열에 포함되어 있어야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/LadderGame.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/LadderGame.tsx',
       'utf-8',
     );
 
@@ -167,7 +167,7 @@ describe('Issue #4: unused variable ladderHeight in calculatePath', () => {
   it('calculatePath 함수 내에 미사용 변수 ladderHeight가 없어야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/LadderGame.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/LadderGame.tsx',
       'utf-8',
     );
 

--- a/src/test/NamePicker.test.tsx
+++ b/src/test/NamePicker.test.tsx
@@ -207,7 +207,7 @@ describe('NamePicker - cancelledRef 타이머 경쟁 조건 방어 (이슈 H-2)'
   it('cancelledRef가 선언되어 있어야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/NamePicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/NamePicker.tsx',
       'utf-8',
     );
     const hasCancelledRef = /const\s+cancelledRef\s*=\s*useRef/.test(source);
@@ -217,7 +217,7 @@ describe('NamePicker - cancelledRef 타이머 경쟁 조건 방어 (이슈 H-2)'
   it('spin 함수 내에서 cancelledRef.current 체크가 있어야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/NamePicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/NamePicker.tsx',
       'utf-8',
     );
     // spin 함수 내부에 cancelledRef.current를 체크하는 guard가 있어야 한다
@@ -228,7 +228,7 @@ describe('NamePicker - cancelledRef 타이머 경쟁 조건 방어 (이슈 H-2)'
   it('handleReset에서 cancelledRef.current를 true로 설정해야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/NamePicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/NamePicker.tsx',
       'utf-8',
     );
     const hasResetCancel = /handleReset[\s\S]*?cancelledRef\.current\s*=\s*true/.test(source);
@@ -238,7 +238,7 @@ describe('NamePicker - cancelledRef 타이머 경쟁 조건 방어 (이슈 H-2)'
   it('startSpin에서 cancelledRef.current를 false로 초기화해야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/NamePicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/NamePicker.tsx',
       'utf-8',
     );
     const hasStartInit = /startSpin[\s\S]*?cancelledRef\.current\s*=\s*false/.test(source);

--- a/src/test/NumberPicker.test.tsx
+++ b/src/test/NumberPicker.test.tsx
@@ -7,7 +7,7 @@ describe('Issue M-2: NumberPicker do-while 무한 루프 방어', () => {
   it('do-while 루프가 제거되고 가용 번호 배열 방식으로 전환되어야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/NumberPicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/NumberPicker.tsx',
       'utf-8',
     );
     // do-while 루프가 없어야 한다
@@ -18,7 +18,7 @@ describe('Issue M-2: NumberPicker do-while 무한 루프 방어', () => {
   it('pickRandom을 import하여 사용해야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/NumberPicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/NumberPicker.tsx',
       'utf-8',
     );
     const hasPickRandomImport = /import\s*\{[^}]*pickRandom[^}]*\}\s*from\s*['"]@\/lib\/random['"]/.test(source);
@@ -28,7 +28,7 @@ describe('Issue M-2: NumberPicker do-while 무한 루프 방어', () => {
   it('가용 번호 배열을 필터링하여 선택하는 패턴이 있어야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/NumberPicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/NumberPicker.tsx',
       'utf-8',
     );
     // .filter(n => !usedNumbers.includes(n)) 패턴이 있어야 한다
@@ -44,7 +44,7 @@ describe('Issue M-4: NumberPicker useEffect cleanup - stale ref 방지', () => {
   it('useEffect cleanup에서 timeoutRef.current를 직접 참조해야 한다 (stale ref 금지)', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/NumberPicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/NumberPicker.tsx',
       'utf-8',
     );
 
@@ -57,7 +57,7 @@ describe('Issue M-4: NumberPicker useEffect cleanup - stale ref 방지', () => {
   it('useEffect cleanup 내부에서 timeoutRef.current를 직접 접근해야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/NumberPicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/NumberPicker.tsx',
       'utf-8',
     );
 

--- a/src/test/PresetPanel.test.tsx
+++ b/src/test/PresetPanel.test.tsx
@@ -1,0 +1,233 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import PresetPanel from '@/components/ui/PresetPanel';
+import { savePreset } from '@/lib/presetStorage';
+import { MESSAGES } from '@/lib/messages';
+import type { NumberPresetData } from '@/types/preset';
+
+// Dialog polyfill is installed globally in src/test/setup.ts
+
+const testData: NumberPresetData = {
+  minValue: 1,
+  maxValue: 45,
+  pickCount: 6,
+  allowDuplicates: false,
+  sortResults: true,
+};
+
+function renderPanel(overrides = {}) {
+  const defaultProps = {
+    gameType: 'number' as const,
+    getCurrentData: () => testData,
+    onLoad: vi.fn(),
+    ...overrides,
+  };
+
+  return {
+    ...render(<PresetPanel<NumberPresetData> {...defaultProps} />),
+    props: defaultProps,
+  };
+}
+
+describe('PresetPanel 삭제 확인 다이얼로그', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // ─── ConfirmDialog Integration ────────────────────────────
+
+  describe('삭제 버튼 클릭 시 ConfirmDialog 표시', () => {
+    it('삭제 버튼 클릭 시 window.confirm 대신 ConfirmDialog가 표시된다', async () => {
+      // Given: 프리셋이 하나 저장되어 있다
+      savePreset<NumberPresetData>('number', 'Test Preset', testData);
+      const user = userEvent.setup();
+
+      renderPanel();
+
+      // When: 삭제 버튼 클릭
+      const deleteButton = screen.getByRole('button', { name: '삭제' });
+      await user.click(deleteButton);
+
+      // Then: ConfirmDialog가 표시된다
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+      expect(within(dialog).getByText(/Test Preset/)).toBeInTheDocument();
+    });
+
+    it('ConfirmDialog에 프리셋 이름이 포함된 메시지가 표시된다', async () => {
+      savePreset<NumberPresetData>('number', 'My Config', testData);
+      const user = userEvent.setup();
+
+      renderPanel();
+
+      const deleteButton = screen.getByRole('button', { name: '삭제' });
+      await user.click(deleteButton);
+
+      // 다이얼로그 메시지에 프리셋 이름이 포함
+      const dialog = screen.getByRole('dialog');
+      expect(within(dialog).getByText(/My Config/)).toBeInTheDocument();
+    });
+  });
+
+  describe('ConfirmDialog 확인/취소 동작', () => {
+    it('확인 버튼 클릭 시 프리셋이 삭제된다', async () => {
+      savePreset<NumberPresetData>('number', 'Delete Me', testData);
+      const user = userEvent.setup();
+
+      renderPanel();
+
+      // 프리셋이 표시된다
+      expect(screen.getByText('Delete Me')).toBeInTheDocument();
+
+      // 삭제 버튼 클릭 -> 다이얼로그 표시
+      const deleteButton = screen.getByRole('button', { name: '삭제' });
+      await user.click(deleteButton);
+
+      // 다이얼로그의 확인 버튼 클릭
+      const dialog = screen.getByRole('dialog');
+      const confirmButton = within(dialog).getByRole('button', { name: '삭제' });
+      await user.click(confirmButton);
+
+      // 프리셋이 삭제된다
+      expect(screen.queryByText('Delete Me')).not.toBeInTheDocument();
+      // 다이얼로그가 닫힌다
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('취소 버튼 클릭 시 프리셋이 유지된다', async () => {
+      savePreset<NumberPresetData>('number', 'Keep Me', testData);
+      const user = userEvent.setup();
+
+      renderPanel();
+
+      // 삭제 버튼 클릭 -> 다이얼로그 표시
+      const deleteButton = screen.getByRole('button', { name: '삭제' });
+      await user.click(deleteButton);
+
+      // 다이얼로그의 취소 버튼 클릭
+      const dialog = screen.getByRole('dialog');
+      const cancelButton = within(dialog).getByRole('button', { name: '취소' });
+      await user.click(cancelButton);
+
+      // 프리셋이 유지된다
+      expect(screen.getByText('Keep Me')).toBeInTheDocument();
+      // 다이얼로그가 닫힌다
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('Escape 키 입력 시 다이얼로그가 닫히고 프리셋이 유지된다', async () => {
+      savePreset<NumberPresetData>('number', 'Stay Here', testData);
+      const user = userEvent.setup();
+
+      renderPanel();
+
+      // 삭제 버튼 클릭
+      const deleteButton = screen.getByRole('button', { name: '삭제' });
+      await user.click(deleteButton);
+
+      // Escape 키 입력
+      const dialog = screen.getByRole('dialog');
+      fireEvent.keyDown(dialog, { key: 'Escape' });
+
+      // 프리셋이 유지된다
+      expect(screen.getByText('Stay Here')).toBeInTheDocument();
+      // 다이얼로그가 닫힌다
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ConfirmDialog 스타일', () => {
+    it('삭제 다이얼로그의 확인 버튼이 danger variant (빨간색) 스타일이다', async () => {
+      savePreset<NumberPresetData>('number', 'Danger Style', testData);
+      const user = userEvent.setup();
+
+      renderPanel();
+
+      const deleteButton = screen.getByRole('button', { name: '삭제' });
+      await user.click(deleteButton);
+
+      const dialog = screen.getByRole('dialog');
+      const confirmButton = within(dialog).getByRole('button', { name: '삭제' });
+      expect(confirmButton.className).toMatch(/bg-red/);
+    });
+  });
+
+  describe('window.confirm 미사용 검증', () => {
+    it('삭제 시 window.confirm이 호출되지 않는다', async () => {
+      savePreset<NumberPresetData>('number', 'No Confirm', testData);
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const user = userEvent.setup();
+
+      renderPanel();
+
+      const deleteButton = screen.getByRole('button', { name: '삭제' });
+      await user.click(deleteButton);
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+  });
+
+  // ─── M-1 / M-3: UI text from constants ────────────────────
+
+  describe('UI 텍스트 상수 사용', () => {
+    it('프리셋 제목이 MESSAGES.preset.title 값과 일치한다', () => {
+      renderPanel();
+
+      expect(screen.getByText(MESSAGES.preset.title)).toBeInTheDocument();
+    });
+
+    it('빈 상태 메시지가 MESSAGES.preset.emptyState 값과 일치한다', () => {
+      renderPanel();
+
+      expect(screen.getByText(MESSAGES.preset.emptyState)).toBeInTheDocument();
+    });
+
+    it('저장 시 빈 이름 에러가 MESSAGES.preset.errors.nameRequired 값과 일치한다', async () => {
+      const user = userEvent.setup();
+      renderPanel();
+
+      // 저장 모드 활성화
+      await user.click(screen.getByText(MESSAGES.preset.saveButton));
+      // 빈 이름으로 저장 시도
+      await user.click(screen.getByRole('button', { name: MESSAGES.common.save }));
+
+      expect(screen.getByText(MESSAGES.preset.errors.nameRequired)).toBeInTheDocument();
+    });
+
+    it('삭제 다이얼로그 제목이 MESSAGES.confirmDialog.deleteTitle 값과 일치한다', async () => {
+      savePreset<NumberPresetData>('number', 'Const Check', testData);
+      const user = userEvent.setup();
+      renderPanel();
+
+      const deleteButton = screen.getByRole('button', { name: MESSAGES.common.delete });
+      await user.click(deleteButton);
+
+      const dialog = screen.getByRole('dialog');
+      expect(within(dialog).getByText(MESSAGES.confirmDialog.deleteTitle)).toBeInTheDocument();
+    });
+  });
+
+  // ─── L-4: Conditional rendering of ConfirmDialog ───────────
+
+  describe('조건부 렌더링', () => {
+    it('deleteTarget이 없을 때 ConfirmDialog가 DOM에 존재하지 않는다', () => {
+      renderPanel();
+
+      // 삭제 버튼을 클릭하지 않은 상태에서는 dialog가 없어야 한다
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('삭제 버튼 클릭 후 ConfirmDialog가 DOM에 존재한다', async () => {
+      savePreset<NumberPresetData>('number', 'Render Check', testData);
+      const user = userEvent.setup();
+      renderPanel();
+
+      const deleteButton = screen.getByRole('button', { name: MESSAGES.common.delete });
+      await user.click(deleteButton);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/test/PrizePicker.test.tsx
+++ b/src/test/PrizePicker.test.tsx
@@ -217,7 +217,7 @@ describe('PrizePicker - cancelledRef 타이머 경쟁 조건 방어 (이슈 H-2)
   it('cancelledRef가 선언되어 있어야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/PrizePicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/PrizePicker.tsx',
       'utf-8',
     );
     const hasCancelledRef = /const\s+cancelledRef\s*=\s*useRef/.test(source);
@@ -227,7 +227,7 @@ describe('PrizePicker - cancelledRef 타이머 경쟁 조건 방어 (이슈 H-2)
   it('spin 함수 내에서 cancelledRef.current 체크가 있어야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/PrizePicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/PrizePicker.tsx',
       'utf-8',
     );
     const hasGuardInSpin = /const\s+spin\s*=\s*\(\s*\)\s*=>\s*\{[\s\S]*?cancelledRef\.current/.test(source);
@@ -237,7 +237,7 @@ describe('PrizePicker - cancelledRef 타이머 경쟁 조건 방어 (이슈 H-2)
   it('handleReset에서 cancelledRef.current를 true로 설정해야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/PrizePicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/PrizePicker.tsx',
       'utf-8',
     );
     const hasResetCancel = /handleReset[\s\S]*?cancelledRef\.current\s*=\s*true/.test(source);
@@ -247,7 +247,7 @@ describe('PrizePicker - cancelledRef 타이머 경쟁 조건 방어 (이슈 H-2)
   it('startSpin에서 cancelledRef.current를 false로 초기화해야 한다', async () => {
     const fs = await import('fs');
     const source = fs.readFileSync(
-      '/Users/kmg733/project/lucky-pick-fix-review/src/components/games/PrizePicker.tsx',
+      '/Users/kmg733/project/lucky-pick/src/components/games/PrizePicker.tsx',
       'utf-8',
     );
     const hasStartInit = /startSpin[\s\S]*?cancelledRef\.current\s*=\s*false/.test(source);

--- a/src/test/helpers/dialogPolyfill.ts
+++ b/src/test/helpers/dialogPolyfill.ts
@@ -1,0 +1,14 @@
+/**
+ * jsdom does not implement HTMLDialogElement.showModal/close.
+ * This polyfill assigns stub methods that track open state via the `open` attribute.
+ *
+ * Imported in src/test/setup.ts so every test file gets it automatically.
+ */
+export function installDialogPolyfill(): void {
+  HTMLDialogElement.prototype.showModal ??= function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  };
+  HTMLDialogElement.prototype.close ??= function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  };
+}

--- a/src/test/helpers/mockLocalStorage.ts
+++ b/src/test/helpers/mockLocalStorage.ts
@@ -4,7 +4,7 @@ export function createLocalStorageMock() {
   let store: Record<string, string> = {};
 
   return {
-    getItem: vi.fn((key: string) => store[key] ?? null),
+    getItem: vi.fn((key: string): string | null => store[key] ?? null),
     setItem: vi.fn((key: string, value: string) => {
       store[key] = value;
     }),

--- a/src/test/presetStorage.test.ts
+++ b/src/test/presetStorage.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { getPresets, savePreset, deletePreset, MAX_PRESETS_PER_GAME, MAX_PRESET_NAME_LENGTH, STORAGE_KEY_PREFIX } from '@/lib/presetStorage';
-import type { NumberPresetData, PrizePresetData, NamePresetData } from '@/types/preset';
+import {
+  getPresets,
+  savePreset,
+  deletePreset,
+  MAX_PRESETS_PER_GAME,
+  MAX_PRESET_NAME_LENGTH,
+  MAX_PRESET_DATA_SIZE,
+  STORAGE_KEY_PREFIX,
+} from '@/lib/presetStorage';
+import type { NumberPresetData, PrizePresetData, NamePresetData, LadderPresetData } from '@/types/preset';
 
 describe('presetStorage', () => {
   beforeEach(() => {
@@ -63,13 +71,14 @@ describe('presetStorage', () => {
       const data: PrizePresetData = { items: 'Gold\nSilver\nBronze' };
 
       const saved = savePreset<PrizePresetData>('prize', 'Prizes', data);
+      expect(saved).not.toBeNull();
 
-      expect(saved.id).toBeTruthy();
-      expect(saved.name).toBe('Prizes');
-      expect(saved.gameType).toBe('prize');
-      expect(saved.data).toEqual(data);
-      expect(saved.createdAt).toBeTypeOf('number');
-      expect(saved.createdAt).toBeGreaterThan(0);
+      expect(saved!.id).toBeTruthy();
+      expect(saved!.name).toBe('Prizes');
+      expect(saved!.gameType).toBe('prize');
+      expect(saved!.data).toEqual(data);
+      expect(saved!.createdAt).toBeTypeOf('number');
+      expect(saved!.createdAt).toBeGreaterThan(0);
     });
 
     it('generates unique IDs for each saved preset', () => {
@@ -77,8 +86,10 @@ describe('presetStorage', () => {
 
       const preset1 = savePreset<PrizePresetData>('prize', 'P1', data);
       const preset2 = savePreset<PrizePresetData>('prize', 'P2', data);
+      expect(preset1).not.toBeNull();
+      expect(preset2).not.toBeNull();
 
-      expect(preset1.id).not.toBe(preset2.id);
+      expect(preset1!.id).not.toBe(preset2!.id);
     });
 
     it('persists preset to localStorage', () => {
@@ -148,8 +159,9 @@ describe('presetStorage', () => {
     it('deletes a preset by ID', () => {
       const data: PrizePresetData = { items: 'item' };
       const saved = savePreset<PrizePresetData>('prize', 'To Delete', data);
+      expect(saved).not.toBeNull();
 
-      deletePreset('prize', saved.id);
+      deletePreset('prize', saved!.id);
 
       const result = getPresets<PrizePresetData>('prize');
       expect(result).toHaveLength(0);
@@ -159,12 +171,14 @@ describe('presetStorage', () => {
       const data: PrizePresetData = { items: 'item' };
       const preset1 = savePreset<PrizePresetData>('prize', 'Keep', data);
       const preset2 = savePreset<PrizePresetData>('prize', 'Delete', data);
+      expect(preset1).not.toBeNull();
+      expect(preset2).not.toBeNull();
 
-      deletePreset('prize', preset2.id);
+      deletePreset('prize', preset2!.id);
 
       const result = getPresets<PrizePresetData>('prize');
       expect(result).toHaveLength(1);
-      expect(result[0].id).toBe(preset1.id);
+      expect(result[0].id).toBe(preset1!.id);
       expect(result[0].name).toBe('Keep');
     });
 
@@ -223,16 +237,18 @@ describe('presetStorage', () => {
       const longName = 'A'.repeat(100);
       const data: PrizePresetData = { items: 'item' };
       const saved = savePreset<PrizePresetData>('prize', longName, data);
+      expect(saved).not.toBeNull();
 
-      expect(saved.name).toHaveLength(MAX_PRESET_NAME_LENGTH);
-      expect(saved.name).toBe('A'.repeat(MAX_PRESET_NAME_LENGTH));
+      expect(saved!.name).toHaveLength(MAX_PRESET_NAME_LENGTH);
+      expect(saved!.name).toBe('A'.repeat(MAX_PRESET_NAME_LENGTH));
     });
 
     it('does not truncate names within the limit', () => {
       const data: PrizePresetData = { items: 'item' };
       const saved = savePreset<PrizePresetData>('prize', 'Short Name', data);
+      expect(saved).not.toBeNull();
 
-      expect(saved.name).toBe('Short Name');
+      expect(saved!.name).toBe('Short Name');
     });
   });
 
@@ -264,6 +280,248 @@ describe('presetStorage', () => {
 
     it('STORAGE_KEY_PREFIX is correct', () => {
       expect(STORAGE_KEY_PREFIX).toBe('lucky-pick-presets-');
+    });
+
+    it('MAX_PRESET_DATA_SIZE is 50000', () => {
+      expect(MAX_PRESET_DATA_SIZE).toBe(50000);
+    });
+  });
+
+  // ─── H-1: Name sanitization ──────────────────────────────────
+
+  describe('savePreset - name sanitization (H-1)', () => {
+    it('removes < > " \' & characters from preset name', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', 'Test<script>"name\'&', data);
+
+      expect(saved).not.toBeNull();
+      expect(saved!.name).not.toContain('<');
+      expect(saved!.name).not.toContain('>');
+      expect(saved!.name).not.toContain('"');
+      expect(saved!.name).not.toContain("'");
+      expect(saved!.name).not.toContain('&');
+      expect(saved!.name).toBe('Testscriptname');
+    });
+
+    it('preserves normal characters after sanitization', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', 'Normal Name 123', data);
+
+      expect(saved).not.toBeNull();
+      expect(saved!.name).toBe('Normal Name 123');
+    });
+
+    it('sanitizes before truncation', () => {
+      // Name with special chars making it long; after sanitizing + truncating
+      const nameWithSpecials = '<>'.repeat(20) + 'A'.repeat(MAX_PRESET_NAME_LENGTH);
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', nameWithSpecials, data);
+
+      expect(saved).not.toBeNull();
+      expect(saved!.name).toHaveLength(MAX_PRESET_NAME_LENGTH);
+      expect(saved!.name).not.toContain('<');
+      expect(saved!.name).not.toContain('>');
+    });
+  });
+
+  // ─── H-2: Game-specific data validation ──────────────────────
+
+  describe('getPresets - game-specific data validation (H-2)', () => {
+    it('filters out prize presets with non-string items', () => {
+      const items = [
+        { id: 'a', name: 'Valid', gameType: 'prize', data: { items: 'Gold\nSilver' }, createdAt: 1000 },
+        { id: 'b', name: 'Invalid', gameType: 'prize', data: { items: 123 }, createdAt: 1001 },
+        { id: 'c', name: 'Missing', gameType: 'prize', data: {}, createdAt: 1002 },
+      ];
+      localStorage.setItem(`${STORAGE_KEY_PREFIX}prize`, JSON.stringify(items));
+
+      const result = getPresets<PrizePresetData>('prize');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('a');
+    });
+
+    it('filters out name presets with invalid structure', () => {
+      const items = [
+        { id: 'a', name: 'Valid', gameType: 'name', data: { names: 'Alice\nBob', pickCount: 1, removeAfterPick: false }, createdAt: 1000 },
+        { id: 'b', name: 'BadPick', gameType: 'name', data: { names: 'Alice', pickCount: 'one', removeAfterPick: false }, createdAt: 1001 },
+        { id: 'c', name: 'NoNames', gameType: 'name', data: { pickCount: 1, removeAfterPick: true }, createdAt: 1002 },
+      ];
+      localStorage.setItem(`${STORAGE_KEY_PREFIX}name`, JSON.stringify(items));
+
+      const result = getPresets<NamePresetData>('name');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('a');
+    });
+
+    it('filters out number presets with invalid structure', () => {
+      const items = [
+        { id: 'a', name: 'Valid', gameType: 'number', data: { minValue: 1, maxValue: 100, pickCount: 3, allowDuplicates: false, sortResults: true }, createdAt: 1000 },
+        { id: 'b', name: 'BadMin', gameType: 'number', data: { minValue: 'one', maxValue: 100, pickCount: 3, allowDuplicates: false, sortResults: true }, createdAt: 1001 },
+        { id: 'c', name: 'MissingSort', gameType: 'number', data: { minValue: 1, maxValue: 100, pickCount: 3, allowDuplicates: false }, createdAt: 1002 },
+      ];
+      localStorage.setItem(`${STORAGE_KEY_PREFIX}number`, JSON.stringify(items));
+
+      const result = getPresets<NumberPresetData>('number');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('a');
+    });
+
+    it('filters out ladder presets with invalid structure', () => {
+      const items = [
+        { id: 'a', name: 'Valid', gameType: 'ladder', data: { participantCount: 3, participantNames: ['A', 'B', 'C'], resultNames: ['1', '2', '3'] }, createdAt: 1000 },
+        { id: 'b', name: 'BadCount', gameType: 'ladder', data: { participantCount: 'three', participantNames: ['A'], resultNames: ['1'] }, createdAt: 1001 },
+        { id: 'c', name: 'NotArray', gameType: 'ladder', data: { participantCount: 2, participantNames: 'A,B', resultNames: ['1'] }, createdAt: 1002 },
+      ];
+      localStorage.setItem(`${STORAGE_KEY_PREFIX}ladder`, JSON.stringify(items));
+
+      const result = getPresets<LadderPresetData>('ladder');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('a');
+    });
+  });
+
+  // ─── M-1: crypto.randomUUID ──────────────────────────────────
+
+  describe('savePreset - ID generation (M-1)', () => {
+    it('generates valid string IDs', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', 'Test', data);
+
+      expect(saved).not.toBeNull();
+      expect(saved!.id).toBeTruthy();
+      expect(typeof saved!.id).toBe('string');
+      expect(saved!.id.length).toBeGreaterThan(0);
+    });
+
+    it('uses crypto.randomUUID when available', () => {
+      const mockUUID = '550e8400-e29b-41d4-a716-446655440000';
+      const randomUUIDSpy = vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(mockUUID as `${string}-${string}-${string}-${string}-${string}`);
+
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', 'Test', data);
+
+      expect(saved).not.toBeNull();
+      expect(saved!.id).toBe(mockUUID);
+
+      randomUUIDSpy.mockRestore();
+    });
+
+    it('falls back when crypto.randomUUID is not available', () => {
+      const randomUUIDSpy = vi.spyOn(globalThis.crypto, 'randomUUID').mockImplementation(() => {
+        throw new Error('not supported');
+      });
+
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', 'Test', data);
+
+      expect(saved).not.toBeNull();
+      expect(saved!.id).toBeTruthy();
+      expect(typeof saved!.id).toBe('string');
+      // Should not be a UUID format since fallback was used
+      expect(saved!.id).not.toContain('-');
+
+      randomUUIDSpy.mockRestore();
+    });
+  });
+
+  // ─── M-2: deletePreset returns boolean ────────────────────────
+
+  describe('deletePreset - returns boolean (M-2)', () => {
+    it('returns true when preset is successfully deleted', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', 'ToDelete', data);
+      expect(saved).not.toBeNull();
+
+      const result = deletePreset('prize', saved!.id);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when preset ID does not exist', () => {
+      const data: PrizePresetData = { items: 'item' };
+      savePreset<PrizePresetData>('prize', 'Existing', data);
+
+      const result = deletePreset('prize', 'non-existent-id');
+      expect(result).toBe(false);
+    });
+
+    it('returns false when no presets exist for the game type', () => {
+      const result = deletePreset('ladder', 'some-id');
+      expect(result).toBe(false);
+    });
+
+    it('returns false when localStorage write fails during delete', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', 'Test', data);
+      expect(saved).not.toBeNull();
+
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      const result = deletePreset('prize', saved!.id);
+      expect(result).toBe(false);
+    });
+  });
+
+  // ─── L-1: Data size limit ────────────────────────────────────
+
+  describe('savePreset - data size limit (L-1)', () => {
+    it('returns null when data exceeds MAX_PRESET_DATA_SIZE', () => {
+      const hugeItems = 'x'.repeat(MAX_PRESET_DATA_SIZE + 1);
+      const data: PrizePresetData = { items: hugeItems };
+
+      const saved = savePreset<PrizePresetData>('prize', 'Huge', data);
+      expect(saved).toBeNull();
+    });
+
+    it('allows data within MAX_PRESET_DATA_SIZE', () => {
+      const normalItems = 'x'.repeat(100);
+      const data: PrizePresetData = { items: normalItems };
+
+      const saved = savePreset<PrizePresetData>('prize', 'Normal', data);
+      expect(saved).not.toBeNull();
+      expect(saved!.name).toBe('Normal');
+    });
+  });
+
+  // ─── L-2: Name trim + empty check ────────────────────────────
+
+  describe('savePreset - name trim (L-2)', () => {
+    it('trims whitespace from preset name', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', '  My Preset  ', data);
+
+      expect(saved).not.toBeNull();
+      expect(saved!.name).toBe('My Preset');
+    });
+
+    it('returns null when name is empty after trim', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', '   ', data);
+
+      expect(saved).toBeNull();
+    });
+
+    it('returns null when name is empty after sanitization and trim', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', ' <>"\'& ', data);
+
+      expect(saved).toBeNull();
+    });
+  });
+
+  // ─── L-4/L-5: Non-null assertion safety ──────────────────────
+
+  describe('savePreset - non-null assertion safety (L-4/L-5)', () => {
+    it('returns non-null result for valid save operation', () => {
+      const data: PrizePresetData = { items: 'Gold\nSilver' };
+      const saved = savePreset<PrizePresetData>('prize', 'Test', data);
+
+      expect(saved).not.toBeNull();
+      expect(saved!.id).toBeTruthy();
+      expect(saved!.name).toBe('Test');
+      expect(saved!.gameType).toBe('prize');
+      expect(saved!.data).toEqual(data);
     });
   });
 });

--- a/src/test/presetStorage.test.ts
+++ b/src/test/presetStorage.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getPresets, savePreset, deletePreset, MAX_PRESETS_PER_GAME, MAX_PRESET_NAME_LENGTH, STORAGE_KEY_PREFIX } from '@/lib/presetStorage';
+import type { NumberPresetData, PrizePresetData, NamePresetData } from '@/types/preset';
+
+describe('presetStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  // ─── getPresets ───────────────────────────────────────────────
+
+  describe('getPresets', () => {
+    it('returns empty array when no presets exist', () => {
+      const result = getPresets<NumberPresetData>('number');
+      expect(result).toEqual([]);
+    });
+
+    it('returns saved presets for a given game type', () => {
+      const data: NumberPresetData = {
+        minValue: 1,
+        maxValue: 100,
+        pickCount: 3,
+        allowDuplicates: false,
+        sortResults: true,
+      };
+      savePreset<NumberPresetData>('number', 'My Number Preset', data);
+
+      const result = getPresets<NumberPresetData>('number');
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('My Number Preset');
+      expect(result[0].gameType).toBe('number');
+      expect(result[0].data).toEqual(data);
+    });
+
+    it('returns empty array when localStorage contains corrupted JSON', () => {
+      localStorage.setItem(`${STORAGE_KEY_PREFIX}prize`, 'not-valid-json{{{');
+
+      const result = getPresets<PrizePresetData>('prize');
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when localStorage contains non-array JSON', () => {
+      localStorage.setItem(`${STORAGE_KEY_PREFIX}prize`, '{"key": "value"}');
+
+      const result = getPresets<PrizePresetData>('prize');
+      expect(result).toEqual([]);
+    });
+
+    it('does not return presets from different game types', () => {
+      const prizeData: PrizePresetData = { items: 'item1\nitem2' };
+      savePreset<PrizePresetData>('prize', 'Prize Preset', prizeData);
+
+      const result = getPresets<NumberPresetData>('number');
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─── savePreset ──────────────────────────────────────────────
+
+  describe('savePreset', () => {
+    it('saves a new preset and returns it with id, createdAt, and gameType', () => {
+      const data: PrizePresetData = { items: 'Gold\nSilver\nBronze' };
+
+      const saved = savePreset<PrizePresetData>('prize', 'Prizes', data);
+
+      expect(saved.id).toBeTruthy();
+      expect(saved.name).toBe('Prizes');
+      expect(saved.gameType).toBe('prize');
+      expect(saved.data).toEqual(data);
+      expect(saved.createdAt).toBeTypeOf('number');
+      expect(saved.createdAt).toBeGreaterThan(0);
+    });
+
+    it('generates unique IDs for each saved preset', () => {
+      const data: PrizePresetData = { items: 'item' };
+
+      const preset1 = savePreset<PrizePresetData>('prize', 'P1', data);
+      const preset2 = savePreset<PrizePresetData>('prize', 'P2', data);
+
+      expect(preset1.id).not.toBe(preset2.id);
+    });
+
+    it('persists preset to localStorage', () => {
+      const data: NamePresetData = {
+        names: 'Alice\nBob',
+        pickCount: 1,
+        removeAfterPick: false,
+      };
+      savePreset<NamePresetData>('name', 'Names', data);
+
+      const raw = localStorage.getItem(`${STORAGE_KEY_PREFIX}name`);
+      expect(raw).toBeTruthy();
+
+      const parsed = JSON.parse(raw!);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].name).toBe('Names');
+    });
+
+    it('allows saving up to MAX_PRESETS_PER_GAME presets', () => {
+      const data: PrizePresetData = { items: 'item' };
+
+      for (let i = 0; i < MAX_PRESETS_PER_GAME; i++) {
+        savePreset<PrizePresetData>('prize', `Preset ${i}`, data);
+      }
+
+      const result = getPresets<PrizePresetData>('prize');
+      expect(result).toHaveLength(MAX_PRESETS_PER_GAME);
+    });
+
+    it('removes the oldest preset when exceeding MAX_PRESETS_PER_GAME', () => {
+      const data: PrizePresetData = { items: 'item' };
+
+      // Save MAX presets
+      for (let i = 0; i < MAX_PRESETS_PER_GAME; i++) {
+        savePreset<PrizePresetData>('prize', `Preset ${i}`, data);
+      }
+
+      // Save one more - should evict the oldest (Preset 0)
+      savePreset<PrizePresetData>('prize', 'Newest Preset', data);
+
+      const result = getPresets<PrizePresetData>('prize');
+      expect(result).toHaveLength(MAX_PRESETS_PER_GAME);
+
+      const names = result.map((p) => p.name);
+      expect(names).not.toContain('Preset 0');
+      expect(names).toContain('Newest Preset');
+    });
+
+    it('handles localStorage write failure gracefully and returns null', () => {
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      const data: PrizePresetData = { items: 'item' };
+
+      // Should not throw even when localStorage fails
+      const result = savePreset<PrizePresetData>('prize', 'Test', data);
+      expect(result).toBeNull();
+
+      setItemSpy.mockRestore();
+    });
+  });
+
+  // ─── deletePreset ────────────────────────────────────────────
+
+  describe('deletePreset', () => {
+    it('deletes a preset by ID', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', 'To Delete', data);
+
+      deletePreset('prize', saved.id);
+
+      const result = getPresets<PrizePresetData>('prize');
+      expect(result).toHaveLength(0);
+    });
+
+    it('only deletes the specified preset, keeping others intact', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const preset1 = savePreset<PrizePresetData>('prize', 'Keep', data);
+      const preset2 = savePreset<PrizePresetData>('prize', 'Delete', data);
+
+      deletePreset('prize', preset2.id);
+
+      const result = getPresets<PrizePresetData>('prize');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(preset1.id);
+      expect(result[0].name).toBe('Keep');
+    });
+
+    it('does nothing when deleting a non-existent ID', () => {
+      const data: PrizePresetData = { items: 'item' };
+      savePreset<PrizePresetData>('prize', 'Existing', data);
+
+      // Should not throw
+      expect(() => deletePreset('prize', 'non-existent-id')).not.toThrow();
+
+      const result = getPresets<PrizePresetData>('prize');
+      expect(result).toHaveLength(1);
+    });
+
+    it('does nothing when no presets exist for the game type', () => {
+      expect(() => deletePreset('ladder', 'some-id')).not.toThrow();
+    });
+  });
+
+  // ─── getPresets - structure validation (H-1) ────────────────
+
+  describe('getPresets - structure validation', () => {
+    it('filters out array items missing required fields', () => {
+      const malformed = [
+        { id: 'valid', name: 'Test', gameType: 'prize', data: { items: 'a' }, createdAt: 1000 },
+        { name: 'no-id' },
+        { id: 123, name: 'bad-id-type', gameType: 'prize', data: {}, createdAt: 1000 },
+        'just a string',
+        null,
+      ];
+      localStorage.setItem(`${STORAGE_KEY_PREFIX}prize`, JSON.stringify(malformed));
+
+      const result = getPresets<PrizePresetData>('prize');
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Test');
+    });
+
+    it('filters out items where data is not an object', () => {
+      const items = [
+        { id: 'a', name: 'N', gameType: 'prize', data: 'string-data', createdAt: 1000 },
+        { id: 'b', name: 'M', gameType: 'prize', data: null, createdAt: 1000 },
+        { id: 'c', name: 'O', gameType: 'prize', data: { items: 'ok' }, createdAt: 1000 },
+      ];
+      localStorage.setItem(`${STORAGE_KEY_PREFIX}prize`, JSON.stringify(items));
+
+      const result = getPresets<PrizePresetData>('prize');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('c');
+    });
+  });
+
+  // ─── savePreset - name truncation (H-2) ────────────────────
+
+  describe('savePreset - name handling', () => {
+    it('truncates name to MAX_PRESET_NAME_LENGTH characters', () => {
+      const longName = 'A'.repeat(100);
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', longName, data);
+
+      expect(saved.name).toHaveLength(MAX_PRESET_NAME_LENGTH);
+      expect(saved.name).toBe('A'.repeat(MAX_PRESET_NAME_LENGTH));
+    });
+
+    it('does not truncate names within the limit', () => {
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', 'Short Name', data);
+
+      expect(saved.name).toBe('Short Name');
+    });
+  });
+
+  // ─── savePreset - returns null on write failure (M-2) ──────
+
+  describe('savePreset - write failure', () => {
+    it('returns null when localStorage write fails', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      const data: PrizePresetData = { items: 'item' };
+      const saved = savePreset<PrizePresetData>('prize', 'Test', data);
+
+      expect(saved).toBeNull();
+    });
+  });
+
+  // ─── Constants ───────────────────────────────────────────────
+
+  describe('Constants', () => {
+    it('MAX_PRESETS_PER_GAME is 5', () => {
+      expect(MAX_PRESETS_PER_GAME).toBe(5);
+    });
+
+    it('MAX_PRESET_NAME_LENGTH is 30', () => {
+      expect(MAX_PRESET_NAME_LENGTH).toBe(30);
+    });
+
+    it('STORAGE_KEY_PREFIX is correct', () => {
+      expect(STORAGE_KEY_PREFIX).toBe('lucky-pick-presets-');
+    });
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom/vitest';
+import { installDialogPolyfill } from './helpers/dialogPolyfill';
+
+// Install HTMLDialogElement polyfill for jsdom globally.
+// Individual test files no longer need their own beforeEach for showModal/close.
+installDialogPolyfill();

--- a/src/test/usePreset.test.tsx
+++ b/src/test/usePreset.test.tsx
@@ -181,6 +181,37 @@ describe('usePreset', () => {
       const parsed = JSON.parse(raw!);
       expect(parsed).toHaveLength(0);
     });
+
+    it('returns true when successfully deleting an existing preset (M-2)', () => {
+      const { result } = renderHook(() => usePreset<PrizePresetData>('prize'));
+
+      const data: PrizePresetData = { items: 'item' };
+
+      act(() => {
+        result.current.savePreset('Delete Me', data);
+      });
+
+      const presetId = result.current.presets[0].id;
+      let deleteResult: boolean = false;
+
+      act(() => {
+        deleteResult = result.current.deletePreset(presetId);
+      });
+
+      expect(deleteResult).toBe(true);
+    });
+
+    it('returns false when deleting a non-existent preset (M-2)', () => {
+      const { result } = renderHook(() => usePreset<PrizePresetData>('prize'));
+
+      let deleteResult: boolean = true;
+
+      act(() => {
+        deleteResult = result.current.deletePreset('non-existent-id');
+      });
+
+      expect(deleteResult).toBe(false);
+    });
   });
 
   // ─── Game Type Isolation ────────────────────────────────────

--- a/src/test/usePreset.test.tsx
+++ b/src/test/usePreset.test.tsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePreset } from '@/hooks/usePreset';
+import { savePreset as storageSavePreset } from '@/lib/presetStorage';
+import type { NumberPresetData, PrizePresetData } from '@/types/preset';
+
+describe('usePreset', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // ─── Initial Rendering ──────────────────────────────────────
+
+  describe('initial rendering', () => {
+    it('returns empty presets list when no presets exist', () => {
+      const { result } = renderHook(() => usePreset<NumberPresetData>('number'));
+
+      expect(result.current.presets).toEqual([]);
+    });
+
+    it('loads existing presets from localStorage on mount', () => {
+      const data: NumberPresetData = {
+        minValue: 1,
+        maxValue: 50,
+        pickCount: 5,
+        allowDuplicates: false,
+        sortResults: true,
+      };
+      storageSavePreset<NumberPresetData>('number', 'Existing Preset', data);
+
+      const { result } = renderHook(() => usePreset<NumberPresetData>('number'));
+
+      expect(result.current.presets).toHaveLength(1);
+      expect(result.current.presets[0].name).toBe('Existing Preset');
+      expect(result.current.presets[0].data).toEqual(data);
+    });
+  });
+
+  // ─── savePreset ─────────────────────────────────────────────
+
+  describe('savePreset', () => {
+    it('adds a preset to the list when savePreset is called', () => {
+      const { result } = renderHook(() => usePreset<NumberPresetData>('number'));
+
+      const data: NumberPresetData = {
+        minValue: 1,
+        maxValue: 100,
+        pickCount: 3,
+        allowDuplicates: false,
+        sortResults: true,
+      };
+
+      act(() => {
+        result.current.savePreset('My Number Preset', data);
+      });
+
+      expect(result.current.presets).toHaveLength(1);
+      expect(result.current.presets[0].name).toBe('My Number Preset');
+      expect(result.current.presets[0].gameType).toBe('number');
+      expect(result.current.presets[0].data).toEqual(data);
+    });
+
+    it('persists saved preset to localStorage', () => {
+      const { result } = renderHook(() => usePreset<PrizePresetData>('prize'));
+
+      const data: PrizePresetData = { items: 'Gold\nSilver' };
+
+      act(() => {
+        result.current.savePreset('Prize Set', data);
+      });
+
+      // Verify by reading directly from localStorage
+      const raw = localStorage.getItem('lucky-pick-presets-prize');
+      expect(raw).toBeTruthy();
+
+      const parsed = JSON.parse(raw!);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].name).toBe('Prize Set');
+    });
+  });
+
+  // ─── loadPreset ─────────────────────────────────────────────
+
+  describe('loadPreset', () => {
+    it('returns preset data when given a valid ID', () => {
+      const { result } = renderHook(() => usePreset<NumberPresetData>('number'));
+
+      const data: NumberPresetData = {
+        minValue: 10,
+        maxValue: 99,
+        pickCount: 2,
+        allowDuplicates: true,
+        sortResults: false,
+      };
+
+      act(() => {
+        result.current.savePreset('Loadable Preset', data);
+      });
+
+      const savedId = result.current.presets[0].id;
+      const loaded = result.current.loadPreset(savedId);
+
+      expect(loaded).toEqual(data);
+    });
+
+    it('returns null when given a non-existent ID', () => {
+      const { result } = renderHook(() => usePreset<NumberPresetData>('number'));
+
+      const loaded = result.current.loadPreset('non-existent-id');
+
+      expect(loaded).toBeNull();
+    });
+  });
+
+  // ─── deletePreset ───────────────────────────────────────────
+
+  describe('deletePreset', () => {
+    it('removes a preset from the list when deletePreset is called', () => {
+      const { result } = renderHook(() => usePreset<PrizePresetData>('prize'));
+
+      const data: PrizePresetData = { items: 'item1\nitem2' };
+
+      act(() => {
+        result.current.savePreset('To Delete', data);
+      });
+
+      expect(result.current.presets).toHaveLength(1);
+
+      const presetId = result.current.presets[0].id;
+
+      act(() => {
+        result.current.deletePreset(presetId);
+      });
+
+      expect(result.current.presets).toHaveLength(0);
+    });
+
+    it('only removes the specified preset, keeping others intact', () => {
+      const { result } = renderHook(() => usePreset<PrizePresetData>('prize'));
+
+      const data: PrizePresetData = { items: 'item' };
+
+      act(() => {
+        result.current.savePreset('Keep This', data);
+      });
+
+      act(() => {
+        result.current.savePreset('Delete This', data);
+      });
+
+      expect(result.current.presets).toHaveLength(2);
+
+      const toDeleteId = result.current.presets.find(
+        (p) => p.name === 'Delete This'
+      )!.id;
+
+      act(() => {
+        result.current.deletePreset(toDeleteId);
+      });
+
+      expect(result.current.presets).toHaveLength(1);
+      expect(result.current.presets[0].name).toBe('Keep This');
+    });
+
+    it('persists deletion to localStorage', () => {
+      const { result } = renderHook(() => usePreset<PrizePresetData>('prize'));
+
+      const data: PrizePresetData = { items: 'item' };
+
+      act(() => {
+        result.current.savePreset('Will Be Deleted', data);
+      });
+
+      const presetId = result.current.presets[0].id;
+
+      act(() => {
+        result.current.deletePreset(presetId);
+      });
+
+      const raw = localStorage.getItem('lucky-pick-presets-prize');
+      const parsed = JSON.parse(raw!);
+      expect(parsed).toHaveLength(0);
+    });
+  });
+
+  // ─── Game Type Isolation ────────────────────────────────────
+
+  describe('game type isolation', () => {
+    it('manages presets independently per game type', () => {
+      const { result: numberHook } = renderHook(() =>
+        usePreset<NumberPresetData>('number')
+      );
+      const { result: prizeHook } = renderHook(() =>
+        usePreset<PrizePresetData>('prize')
+      );
+
+      const numberData: NumberPresetData = {
+        minValue: 1,
+        maxValue: 100,
+        pickCount: 1,
+        allowDuplicates: false,
+        sortResults: false,
+      };
+
+      const prizeData: PrizePresetData = { items: 'Gold\nSilver' };
+
+      act(() => {
+        numberHook.current.savePreset('Number Preset', numberData);
+      });
+
+      act(() => {
+        prizeHook.current.savePreset('Prize Preset', prizeData);
+      });
+
+      expect(numberHook.current.presets).toHaveLength(1);
+      expect(numberHook.current.presets[0].name).toBe('Number Preset');
+      expect(numberHook.current.presets[0].gameType).toBe('number');
+
+      expect(prizeHook.current.presets).toHaveLength(1);
+      expect(prizeHook.current.presets[0].name).toBe('Prize Preset');
+      expect(prizeHook.current.presets[0].gameType).toBe('prize');
+    });
+  });
+});

--- a/src/types/preset.ts
+++ b/src/types/preset.ts
@@ -1,0 +1,45 @@
+import type { GameType } from './index';
+
+/** Prize game preset data - items stored as newline-separated text */
+export interface PrizePresetData {
+  items: string;
+}
+
+/** Name picker preset data */
+export interface NamePresetData {
+  names: string;
+  pickCount: number;
+  removeAfterPick: boolean;
+}
+
+/** Number picker preset data */
+export interface NumberPresetData {
+  minValue: number;
+  maxValue: number;
+  pickCount: number;
+  allowDuplicates: boolean;
+  sortResults: boolean;
+}
+
+/** Ladder game preset data */
+export interface LadderPresetData {
+  participantCount: number;
+  participantNames: string[];
+  resultNames: string[];
+}
+
+/** Union of all preset data types */
+export type PresetData =
+  | PrizePresetData
+  | NamePresetData
+  | NumberPresetData
+  | LadderPresetData;
+
+/** A saved preset with metadata */
+export interface Preset<T extends PresetData = PresetData> {
+  id: string;
+  name: string;
+  gameType: GameType;
+  data: T;
+  createdAt: number;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,19 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     css: true,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/lib/**', 'src/hooks/**', 'src/components/**'],
+      exclude: ['src/test/**'],
+      thresholds: {
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- localStorage 기반 프리셋 시스템으로 게임별 설정을 저장/불러오기/삭제 기능 구현
- 4개 게임(경품, 이름, 숫자, 사다리타기) 모두 PresetPanel 컴포넌트 통합
- Vitest + Testing Library 기반 33개 테스트 (presetStorage 23개 + usePreset 10개)

## 주요 변경사항

### 신규 파일
| 파일 | 설명 |
|------|------|
| `src/types/preset.ts` | 게임별 프리셋 데이터 타입 정의 |
| `src/lib/presetStorage.ts` | localStorage CRUD 유틸리티 (구조 검증, FIFO 정리) |
| `src/hooks/usePreset.ts` | React 커스텀 훅 (상태 관리 래퍼) |
| `src/components/ui/PresetPanel.tsx` | 프리셋 저장/불러오기/삭제 UI 컴포넌트 |
| `src/test/presetStorage.test.ts` | presetStorage 단위 테스트 (23개) |
| `src/test/usePreset.test.tsx` | usePreset 훅 테스트 (10개) |
| `vitest.config.ts` | Vitest 테스트 설정 |

### 수정 파일
| 파일 | 변경 내용 |
|------|----------|
| `src/components/games/PrizePicker.tsx` | PresetPanel 통합 (경품 목록 저장) |
| `src/components/games/NamePicker.tsx` | PresetPanel 통합 (이름/추첨수/제거옵션 저장) |
| `src/components/games/NumberPicker.tsx` | PresetPanel 통합 (범위/추첨수/중복/정렬 저장) |
| `src/components/games/LadderGame.tsx` | PresetPanel 통합 (참가자/결과 이름 저장, pendingPresetRef 패턴) |
| `package.json` | vitest, testing-library 의존성 추가 |

### 핵심 기능
- 게임별 최대 **5개** 프리셋 유지 (초과 시 가장 오래된 것 자동 삭제)
- 프리셋 이름 **30자** 제한 + 입력 시 maxLength 적용
- localStorage 데이터 **구조 검증** (isValidPreset 가드)
- 삭제 시 **확인 다이얼로그** (window.confirm)
- localStorage 쓰기 실패 시 **null 반환** (에러 안전 처리)

## Test plan
- [x] `npm test` - 33개 테스트 전체 통과
- [x] `npm run build` - TypeScript 빌드 성공
- [x] 각 게임에서 프리셋 저장 → 불러오기 → 삭제 동작 확인
- [ ] 5개 초과 저장 시 FIFO 정리 확인
- [ ] 브라우저 새로고침 후 프리셋 유지 확인